### PR TITLE
.speakeasy: Configure pypi publishing

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -1,34 +1,35 @@
 name: Generate
 permissions:
-    checks: write
-    contents: write
-    pull-requests: write
-    statuses: write
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
 "on":
-    workflow_dispatch:
-        inputs:
-            force:
-                description: Force generation of SDKs
-                type: boolean
-                default: false
-            push_code_samples_only:
-                description: Force push only code samples from SDK generation
-                type: boolean
-                default: false
-            set_version:
-                description: optionally set a specific SDK version
-                type: string
-    schedule:
-        - cron: 0 0 * * *
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Force generation of SDKs
+        type: boolean
+        default: false
+      push_code_samples_only:
+        description: Force push only code samples from SDK generation
+        type: boolean
+        default: false
+      set_version:
+        description: optionally set a specific SDK version
+        type: string
+  schedule:
+    - cron: 0 0 * * *
 jobs:
-    generate:
-        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
-        with:
-            force: ${{ github.event.inputs.force }}
-            mode: pr
-            push_code_samples_only: ${{ fromJSON(github.event.inputs.push_code_samples_only != '' && github.event.inputs.push_code_samples_only || 'false') }}
-            set_version: ${{ github.event.inputs.set_version }}
-            speakeasy_version: latest
-        secrets:
-            github_access_token: ${{ secrets.GITHUB_TOKEN }}
-            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+  generate:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    with:
+      force: ${{ github.event.inputs.force }}
+      mode: pr
+      push_code_samples_only: ${{ fromJSON(github.event.inputs.push_code_samples_only != '' && github.event.inputs.push_code_samples_only || 'false') }}
+      set_version: ${{ github.event.inputs.set_version }}
+      speakeasy_version: latest
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      pypi_token: ${{ secrets.PYPI_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -1,0 +1,20 @@
+name: Publish
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - RELEASES.md
+      - '*/RELEASES.md'
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      pypi_token: ${{ secrets.PYPI_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -10,6 +10,9 @@ targets:
     livepeer-ai-python:
         target: python
         source: livepeer_ai-OAS
+        publish:
+            pypi:
+                token: $pypi_token
         codeSamples:
             output: codeSamples.yaml
             registry:


### PR DESCRIPTION
Using separate livepeer-ai account while I don't get access to the main livepeer account. We can transfer the pakcage between accounts later.